### PR TITLE
Add webpage highlights in resources, tweak style

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -1,76 +1,100 @@
 ## Resources
 
-[Escaping cosmology's failing paradigm](https://iai.tv/articles/escaping-cosmologys-failing-paradigm-auid-1964?_auid=2020)<br>
-By Bjørn Ekeberg and Louis Marmet - iai news - 2021 Nov. 4
+[Escaping cosmology's failing paradigm](https://iai.tv/articles/escaping-cosmologys-failing-paradigm-auid-1964?_auid=2020)\
+**Bjørn Ekeberg and Louis Marmet** - iai news - 2021 Nov. 4
 The current orthodoxy of cosmology rests on unexamined assumptions that have massive implications for our view of the universe. From the size of the universe to its expansion, does the whole programme fail if one of these assumptions turns out to be wrong?
 
-[Is Infinity Real?](http://backreaction.blogspot.com/2020/12/is-infinity-real_5.html)<br>
-By Sabine Hossenfelder - BackRe(Action) - 2020 Dec. 5  In the scientific sense, infinity does not exist. That’s because scientifically we can only say that an element of a theory of nature “exists” if it is necessary to describe observations. And since we cannot measure infinity, we do not actually need it to describe what we observe.
+[Is Infinity Real?](http://backreaction.blogspot.com/2020/12/is-infinity-real_5.html)\
+**Sabine Hossenfelder** - BackRe(Action) - 2020 Dec. 5  In the scientific sense, infinity does not exist. That’s because scientifically we can only say that an element of a theory of nature “exists” if it is necessary to describe observations. And since we cannot measure infinity, we do not actually need it to describe what we observe.
 
-[The Crisis in Cosmology is now catastrophic](https://darkmattercrisis.wordpress.com/2020/11/10/the-crisis-in-cosmology-is-now-catastrophic/)<br>
-By Pavel Kroupa - The Dark Matter Crisis - 2020 Nov. 10  Below are recent scientific developments which strongly suggest that the standard model of cosmology (the SMoC) which relies on the existence of cold or warm dark matter (C/WDM) particles is not a correct description of the observed Universe.
+[The Crisis in Cosmology is now catastrophic](https://darkmattercrisis.wordpress.com/2020/11/10/the-crisis-in-cosmology-is-now-catastrophic/)\
+**Pavel Kroupa** - The Dark Matter Crisis - 2020 Nov. 10  Below are recent scientific developments which strongly suggest that the standard model of cosmology (the SMoC) which relies on the existence of cold or warm dark matter (C/WDM) particles is not a correct description of the observed Universe.
 
-[A pre-history of the prediction of the amplitude of the second peak of the cosmic microwave background](https://tritonstation.com/2020/07/29/a-pre-history-of-the-prediction-of-the-amplitude-of-the-second-peak-of-the-cosmic-microwave-background/)<br>
-By Stacy McGaugh - tritonstation - 2020 July. 29  In this period, I worked very hard to make things work out for CDM. It had to be so! Yet every time I thought I had found a solution, I realized that I had imposed an assumption that guaranteed the desired result.
+[A pre-history of the prediction of the amplitude of the second peak of the cosmic microwave background](https://tritonstation.com/2020/07/29/a-pre-history-of-the-prediction-of-the-amplitude-of-the-second-peak-of-the-cosmic-microwave-background/)\
+**Stacy McGaugh** - tritonstation - 2020 July. 29  In this period, I worked very hard to make things work out for CDM. It had to be so! Yet every time I thought I had found a solution, I realized that I had imposed an assumption that guaranteed the desired result.
 
-[No, physicists have not explained why there is more matter than anti-matter in the universe. It’s not possible.](http://backreaction.blogspot.com/2020/04/no-physicists-have-not-explained-why.html)<br>
-By Sabine Hossenfelder - BackRe(Action) - 2020 Apr. 28  The initial conditions are always assumptions that the theory does not justify.
+[No, physicists have not explained why there is more matter than anti-matter in the universe. It’s not possible.](http://backreaction.blogspot.com/2020/04/no-physicists-have-not-explained-why.html)\
+Sabine Hossenfelder - BackRe(Action) - 2020 Apr. 28  The initial conditions are always assumptions that the theory does not justify.
 
-[Post empirical science is an oxymoron and it is dangerous. But is it science?](https://aeon.co/essays/post-empirical-science-is-an-oxymoron-and-it-is-dangerous)<br>
-By Jim Baggott - aeon - 2019 Oct. 7  There is no agreed criterion to distinguish science from pseudoscience, or just plain ordinary bullshit, opening the door to all manner of metaphysics masquerading as science. This is ‘post-empirical’ science, where truth no longer matters, and it is potentially very dangerous.
+[Post empirical science is an oxymoron and it is dangerous. But is it science?](https://aeon.co/essays/post-empirical-science-is-an-oxymoron-and-it-is-dangerous)\
+**Jim Baggott** - aeon - 2019 Oct. 7  There is no agreed criterion to distinguish science from pseudoscience, or just plain ordinary bullshit, opening the door to all manner of metaphysics masquerading as science. This is ‘post-empirical’ science, where truth no longer matters, and it is potentially very dangerous.
 
-[Redshifts and paradigm shifts: in defence of Hubble’s Law](https://arxiv.org/abs/1909.07731)<br>
-By Cormac O’Raifeartaigh and Michael O’Keeffe - arXiv - 2019 Sept. 17  The proposal by the IAU to rename Hubble’s law as the Hubble-Lemaître law does not represent good historical practice as it conflates Hubble’s observation of a linear relation between redshift and distance with Lemaître’s derivation of a general law of cosmic expansion.
+[Redshifts and paradigm shifts: in defence of Hubble’s Law](https://arxiv.org/abs/1909.07731)\
+**Cormac O’Raifeartaigh and Michael O’Keeffe** - arXiv - 2019 Sept. 17  The proposal by the IAU to rename Hubble’s law as the Hubble-Lemaître law does not represent good historical practice as it conflates Hubble’s observation of a linear relation between redshift and distance with Lemaître’s derivation of a general law of cosmic expansion.
 
-[Cosmology Has Some Big Problems](https://blogs.scientificamerican.com/observations/cosmology-has-some-big-problems/)<br>
-By Bjørn Ekeberg - Scientific American - 2019 Apr. 30  The field relies on a conceptual framework that has trouble accounting for new observations.  What do we really know about our universe?
+[Cosmology Has Some Big Problems](https://blogs.scientificamerican.com/observations/cosmology-has-some-big-problems/)\
+**Bjørn Ekeberg** - Scientific American - 2019 Apr. 30  The field relies on a conceptual framework that has trouble accounting for new observations.  What do we really know about our universe?
 
-[A personal recollection of how we learned to stop worrying and love the Lambda](https://tritonstation.com/2019/01/28/a-personal-recollection-of-how-we-learned-to-stop-worrying-and-love-the-lambda/)<br>
-By Stacy McGaugh - tritonstation - 2019 Jan. 28  We once endowed Standard-CDM with the same absolute certainty we now attribute to ΛCDM. ... SCDM failed. There is nothing so sacred in ΛCDM that it can’t suffer the same fate, as has every single cosmology ever devised by humanity.
+[A personal recollection of how we learned to stop worrying and love the Lambda](https://tritonstation.com/2019/01/28/a-personal-recollection-of-how-we-learned-to-stop-worrying-and-love-the-lambda/)\
+**Stacy McGaugh** - tritonstation - 2019 Jan. 28  We once endowed Standard-CDM with the same absolute certainty we now attribute to ΛCDM. ... SCDM failed. There is nothing so sacred in ΛCDM that it can’t suffer the same fate, as has every single cosmology ever devised by humanity.
 
-[Dark energy is the biggest mystery in cosmology, but it may not exist at all](https://ec.europa.eu/research-and-innovation/en/horizon-magazine/dark-energy-biggest-mystery-cosmology-it-may-not-exist-all-leading-physicist)<br>
-By Jon Cartwright - Horizon Magazine - 2018 Sept. 3
+[Dark energy is the biggest mystery in cosmology, but it may not exist at all](https://ec.europa.eu/research-and-innovation/en/horizon-magazine/dark-energy-biggest-mystery-cosmology-it-may-not-exist-all-leading-physicist)\
+**Jon Cartwright** - Horizon Magazine - 2018 Sept. 3
 The most mysterious phenomenon in cosmology – dark energy – may not exist at all, according to Professor Subir Sarkar, head of the particle theory group at the University of Oxford in the UK.
 
-[Cosmology and Convention](https://arxiv.org/abs/1703.02389)<br>
-By David Merritt - arXiv - 2018 Mar. 7
+[Cosmology and Convention](https://arxiv.org/abs/1703.02389)\
+**David Merritt** - arXiv - 2018 Mar. 7
 The field of cosmology is in a state of "degenerating problemshift" in the language of Imre Lakatos. I show that the "concordance" argument is weaker than the arguments that were made in the past in support of the atomic theory of matter or the quantization of energy.
 
-[Reviewed Publications: challenging Cosmological Models](./reviewed-publications.md)<br>
-By Louis Marmet - ACG - 2018/2020
+[Reviewed Publications: challenging Cosmological Models](./reviewed-publications.md)\
+**Louis Marmet** - ACG - 2018/2020
 Papers challenging cosmological models and observational data of interest to ACG.
 
-[Has dogma derailed the scientific search for dark matter?](https://aeon.co/ideas/has-dogma-derailed-the-scientific-search-for-dark-matter)<br>
-By Pavel Kroupa - aeon - 2016 Nov. 25
+[Has dogma derailed the scientific search for dark matter?](https://aeon.co/ideas/has-dogma-derailed-the-scientific-search-for-dark-matter)\
+**Pavel Kroupa** - aeon - 2016 Nov. 25
 According to mainstream researchers, the vast majority of the matter in the Universe is invisible. The case for dark matter is regarded as so overwhelming that its existence is often reported as fact. Lately, though, cracks of doubt have started to appear.
 
-Astrophysicists, References and Websites https://cosmologyscience.com/ref.htm (website curently down)<br>
-By David Dilworth - Science Based Cosmology - 2014
+[Astrophysicists, References and Websites](https://cosmologyscience.com/ref.htm) (website curently down)\
+**David Dilworth** - Science Based Cosmology - 2014
 One of the clues that something is wrong with "standard" Cosmology is that many of the supporting arguments and credibility are person based ("who says so"), rather than merit or evidence based ("how do they know"). In spite of this I have provided a set of links to leading people as well as the leading arguments for each side of the debate.
 
-[The Crisis of Cosmology](https://www.marxist.com/the-crisis-of-cosmology-part-one.htm)<br>
-By Adam Booth - In Defence of Marxism - 2014 Nov. 17
+[The Crisis of Cosmology](https://www.marxist.com/the-crisis-of-cosmology-part-one.htm)\
+Adam Booth - In Defence of Marxism - 2014 Nov. 17
 The limitations of the existing cosmological models are no secret. The problems facing physics are known to all those who are honest about their work and who sincerely want science to progress.
 
-[Do We Have the Big Bang Theory All Wrong?](https://nautil.us/do-we-have-the-big-bang-theory-all-wrong-234989/)<br>
-By Mark Anderson - Nautilus - 2014 Jul. 31
+[Do We Have the Big Bang Theory All Wrong?](https://nautil.us/do-we-have-the-big-bang-theory-all-wrong-234989/)\
+**Mark Anderson** - Nautilus - 2014 Jul. 31
 A professor of astrophysics at the University of Bonn in Germany, he has taken a stand against nearly the entire field of cosmology by claiming that the diffuse glow of background microwave radiation which bathes the sky is not a distant echo of the Big Bang.
 
-[Dark Matter, Dark Energy and Modern Cosmology: The Case For a Kuhnian Paradigm Shift](https://cosmosandhistory.org/index.php/journal/article/view/161)<br>
-By Jorge Horvath - Cosmos and History - 2009 Nov. 27
+[Dark Matter, Dark Energy and Modern Cosmology: The Case For a Kuhnian Paradigm Shift](https://cosmosandhistory.org/index.php/journal/article/view/161)\
+**Jorge Horvath** - Cosmos and History - 2009 Nov. 27
 Either we are faced to accept the ignorance of at least 95% of the content of the universe or consider a deep change of the conceptual framework. Dark matter and dark energy may be considered as the neo-ether of contemporary physics.
 
-[Sociology of Modern Cosmology](https://arxiv.org/abs/0812.0537)<br>
-By Martín López-Corredoira - arXiv:0812.0537 - 2009 May 18Although the Big Bang is the most commonly accepted theory, it is not the only possible representation of the Cosmos. In this race to build more and more epicycles, Big Bang model is allowed to make ad hoc corrections and add more and more free parameters to the theory to solve the problems which it finds in its way.
+[Sociology of Modern Cosmology](https://arxiv.org/abs/0812.0537)\
+**Martín López-Corredoira** - arXiv:0812.0537 - 2009 May 18Although the Big Bang is the most commonly accepted theory, it is not the only possible representation of the Cosmos. In this race to build more and more epicycles, Big Bang model is allowed to make ad hoc corrections and add more and more free parameters to the theory to solve the problems which it finds in its way.
 
-[Modern Cosmology: Science or Folktale?](https://www.americanscientist.org/article/modern-cosmology-science-or-folktale)<br>
-By Michael J. Disney - American Scientist - 2007 Sept.
+[Modern Cosmology: Science or Folktale?](https://www.americanscientist.org/article/modern-cosmology-science-or-folktale)\
+**Michael J. Disney** - American Scientist - 2007 Sept.
 Current cosmological theory rests on a disturbingly small number of independent observations.
 
-[Did the big bang really happen?](https://www.newscientist.com/article/mg18625061-800-did-the-big-bang-really-happen/)<br>
-By Marcus Chown - New Scientist - 2005 Jul. 2
+[Did the big bang really happen?](https://www.newscientist.com/article/mg18625061-800-did-the-big-bang-really-happen/)\
+**Marcus Chown** - New Scientist - 2005 Jul. 2
 What if the big bang never happened?  Ask cosmologists this and they’ll usually tell you it is a stupid question.  The evidence, after all, is written in the heavens.
 
-[Big Bang not yet dead but in decline](https://www.nature.com/articles/377099a0)<br>
-By John Maddox - Nature - 1995 Sept. 14
+[Big Bang not yet dead but in decline](https://www.nature.com/articles/377099a0)\
+**John Maddox** - Nature - 1995 Sept. 14
 The latest measurements of the Hubble constant make the Big Bang account of the origin of the Universe more dependent on the coincidence of numbers than it has so far been.  But it remains the only theory in the field.
+
+## Webpage highlights
+
+- `2020-02-28` [No dark energy signal despite fudging blind analysis](https://arxiv.org/abs/2002.11124)
+
+- `2020-02-20` [Jean-Claude Pecker](https://www.college-de-france.fr/site/jean-claude-pecker/autoanalyse-du-parcours-scientifique.htm) 1923-2020 had doubts about Big Bang
+
+- `2020-02-20` [Why Physics has made no Progress in 50 Years](https://iai.tv/articles/why-physics-has-made-no-progress-in-50-years-auid-1292)
+
+- `2020-02-20` [In other words, ΛCDM is wrong or incomplete](https://www.quantamagazine.org/what-shape-is-the-universe-closed-or-flat-20191104/)
+
+- `2019-10-23` [The universe is expanding more rapidly than believed.](https://m.phys.org/news/2019-10-crisis-cosmology-universe-rapidly-believed.html) "Therein lies the **crisis in cosmology**" says Chris Fassnacht, Professor of Physics at UC Davis.
+
+- `2019-10-08` Jim Peebles awarded Nobel Prize in physics for ["contributions to our understanding of the evolution of the universe and Earth's place in the cosmos"](https://www.nobelprize.org/prizes/physics/2019/summary/)
+
+- `2019-07-29` Scientific American: [Hubble Tension Headache](https://www.scientificamerican.com/article/hubble-tension-headache-clashing-measurements-make-the-universes-expansion-a-lingering-mystery/)
+
+- `2019-01-24` Dark Matter [remains undetectable](https://m.phys.org/news/2019-01-detector-would-be-evidence-dark.html)
+
+- `2018-11-06` IAU members: It should be known as the [Hubble-Lemaître Law](https://www.iau.org/news/pressreleases/detail/iau1812/)
+
+- `2018-03-14` Obituary by Roger Penrose: [Stephen Hawking](https://www.theguardian.com/science/2018/mar/14/stephen-hawking-obituary)
+
+- `2018-03-08` Jayant Narlikar’s [personal view of Big Bang Cosmology](https://doi.org/10.1140/epjh/e2017-80048-5)


### PR DESCRIPTION
@marmetl I don't know if you want to preserve this `Webpage highlights` section at the bottom of the resources page. I removed the items related to old newsletter announcements and acg back online in 2018. Compare with bottom of [original page.](http://cosmology.info/resources/index.html) Perhaps add these items as resources and remove the `highlights` section? The intent of this section and its difference from `Resources` is not clear to me. I presume these highlights going forward would be announced under Discussions?