### PR TITLE
Change the text for repository button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ theme: just-the-docs
 url: https://a-cosmology-group.github.io
 
 aux_links:  # remove if you don't want this link to appear on your pages
-  Template Repository: https://github.com/a-cosmology-group/acg
+  View it on github: https://github.com/a-cosmology-group/acg
 
 exclude:
 # specific to the website:

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ theme: just-the-docs
 url: https://a-cosmology-group.github.io
 
 aux_links:  # remove if you don't want this link to appear on your pages
-  View it on github: https://github.com/a-cosmology-group/acg
+  View on github: https://github.com/a-cosmology-group/acg
 
 exclude:
 # specific to the website:


### PR DESCRIPTION
The current repository button (top right of webpage) is "Template repository". I propose to change it to "View it on github", which is clearer.